### PR TITLE
feat: add authorization check for pages

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -16,7 +16,7 @@ model Recipe {
   instructions String[]
   User         User?    @relation(fields: [userId], references: [id])
   userId       String?
-
+}
 
 model User {
   id       String   @id @default(uuid())

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,4 @@
-"use client";
-
-import { SessionProvider } from "next-auth/react";
-//import type { Metadata } from "next";
+import type { Metadata } from "next";
 import { AppRouterCacheProvider } from "@mui/material-nextjs/v14-appRouter";
 import { StyledRoot } from "./StyledRoot";
 import { MantineProvider } from "@mantine/core";
@@ -9,11 +6,10 @@ import "@mantine/core/styles.css";
 import "./globals.css";
 import Navbar from "@/components/Navbar";
 
-// metadata can not be used in this way here
-// export const metadata: Metadata = {
-//   title: "Recipe Declutter",
-//   description: "Declutter your favorite recipes here!",
-// };
+export const metadata: Metadata = {
+  title: "Recipe Declutter",
+  description: "Declutter your favorite recipes here!",
+};
 
 export default function RootLayout({
   children,
@@ -23,16 +19,14 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body>
-        <SessionProvider>
-          <MantineProvider>
-            <AppRouterCacheProvider>
-              <StyledRoot>
-                <Navbar />
-                {children}
-              </StyledRoot>
-            </AppRouterCacheProvider>
-          </MantineProvider>
-        </SessionProvider>
+        <MantineProvider>
+          <AppRouterCacheProvider>
+            <StyledRoot>
+              <Navbar />
+              {children}
+            </StyledRoot>
+          </AppRouterCacheProvider>
+        </MantineProvider>
       </body>
     </html>
   );

--- a/src/app/test-page/page.tsx
+++ b/src/app/test-page/page.tsx
@@ -18,8 +18,6 @@ export default function TestPage() {
 
   const router = useRouter();
 
-  const { data: session } = useSession();
-
   const onSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     setError(""); // Reset any errors on submit
@@ -105,11 +103,9 @@ export default function TestPage() {
           <Button type="submit" variant="contained" className="w-full mt-2">
             Logga in
           </Button>
-          {session && (
-            <Button variant="outlined" onClick={() => signOut()}>
-              Sign Out
-            </Button>
-          )}
+          <Button variant="outlined" onClick={() => signOut()}>
+            Sign Out
+          </Button>
         </Box>
       </form>
     </Box>

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -69,6 +69,7 @@ export const authOptions: NextAuthOptions = {
       };
     },
   },
+  secret: process.env.NEXTAUTH_SECRET,
 };
 
 export const getAuth = () => getServerSession(authOptions);

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,3 @@
+export { default } from "next-auth/middleware";
+
+export const config = { matcher: ["/dashboard(.*)"] };

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,3 +1,33 @@
-export { default } from "next-auth/middleware";
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { getToken } from "next-auth/jwt";
 
-export const config = { matcher: ["/dashboard(.*)"] };
+// getServerSession can not be used in middleware. Checking for user token instead.
+
+export async function middleware(request: NextRequest) {
+  // Check for session token
+  const token = await getToken({
+    req: request,
+    secret: process.env.NEXTAUTH_SECRET,
+  });
+
+  // Redirect to login page if there's no token i.e. user is not authenticated
+  if (!token) {
+    return NextResponse.redirect(new URL("/login", request.url));
+  }
+
+  // Redirect authenticated users away from /login and /signup
+  if (token) {
+    const { pathname } = request.nextUrl;
+    if (pathname === "/login" || pathname === "/signup") {
+      return NextResponse.redirect(new URL("/", request.url)); // Redirect to homepage
+    }
+    return NextResponse.next(); // Allow access to other routes
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ["/login/:path*", "/signup/:path*", "/dashboard/:path*"],
+};


### PR DESCRIPTION
This pull request introduces a middleware function that manages route access based on user authentication status. It redirects users trying to access protected routes and ensures that authenticated users are redirected away from login and signup pages.

I initially attempted to use the getAuth function (which relies on getServerSession) but discovered that getServerSession is not usable in NextAuth v4. As a result, this solution uses the getToken function for authentication checks.

Changes Made:

- Created middleware to check user authentication using JWT tokens.
- Implemented route protection for the following paths: ``/dashboard/:path*``, ``/login/:path*``, ``/signup/:path*``
- Redirects unauthenticated users attempting to access the dashboard to the login page.
- Added logic to redirect authenticated users away from login and signup routes to the homepage.