### PR TITLE
fix: nest SessionProvider in a client component

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,29 +1,29 @@
-"use client";
-
-import { SessionProvider } from "next-auth/react";
-//import type { Metadata } from "next";
+import SessionProvider from "@/components/SessionProvider";
+import type { Metadata } from "next";
 import { AppRouterCacheProvider } from "@mui/material-nextjs/v14-appRouter";
 import { StyledRoot } from "./StyledRoot";
 import { MantineProvider } from "@mantine/core";
 import "@mantine/core/styles.css";
 import "./globals.css";
 import Navbar from "@/components/Navbar";
+import { getAuth } from "@/lib/auth";
 
-// metadata can not be used in this way here
-// export const metadata: Metadata = {
-//   title: "Recipe Declutter",
-//   description: "Declutter your favorite recipes here!",
-// };
+export const metadata: Metadata = {
+  title: "Recipe Declutter",
+  description: "Declutter your favorite recipes here!",
+};
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const session = await getAuth();
+
   return (
     <html lang="en">
       <body>
-        <SessionProvider>
+        <SessionProvider session={session}>
           <MantineProvider>
             <AppRouterCacheProvider>
               <StyledRoot>

--- a/src/components/SessionProvider.tsx
+++ b/src/components/SessionProvider.tsx
@@ -1,0 +1,5 @@
+"use client";
+
+import { SessionProvider } from "next-auth/react";
+
+export default SessionProvider;


### PR DESCRIPTION
This PR introduces a way to use SessionProvider from NextAuth while also keeping `app/layout.tsx` as a server component.

---

You can access the session data in any client component like this:

```JS
import { useSession } from "next-auth/react";
import { useEffect } from "react";

...

const session = useSession();
useEffect(() => {
  console.log(session);
}, []);
```

---

Result of console.log when a user is logged in:
<img width="488" alt="Screenshot 2024-10-24 at 13 21 32" src="https://github.com/user-attachments/assets/436e0d7a-6aa0-46f8-9f6e-b858d1c7d417">

> [!NOTE]
> Maybe we should exclude database id from client side logs?

---

Result of console.log when no user is logged in:
<img width="488" alt="Screenshot 2024-10-24 at 13 21 59" src="https://github.com/user-attachments/assets/b46c9816-a657-4cfb-b462-52014ec0be1e">

