### PR TITLE
feat: added logic to handle result if yield is an array

### DIFF
--- a/src/lib/scraper.ts
+++ b/src/lib/scraper.ts
@@ -177,6 +177,9 @@ export const getScrapedRecipe = async (
     // // Get yield (servings)
     let recipeYield = "-";
     if ("recipeYield" in recipeData && recipeData.recipeYield) {
+      if (Array.isArray(recipeData.recipeYield)) {
+        recipeYield = recipeData.recipeYield[0].toString();
+      }
       if (typeof recipeData.recipeYield === "string") {
         // Search for "undefined" and remove it + whitespace
         recipeYield = recipeData.recipeYield

--- a/src/lib/types.d.ts
+++ b/src/lib/types.d.ts
@@ -30,6 +30,10 @@ type Author = {
 
 type ScrapedAuthor = Author | Author[];
 
+type Yield = string | number;
+
+type ScrapedYield = Yield | Yield[];
+
 type RecipeError = {
   message: string;
 };


### PR DESCRIPTION
Sometimes, the yield is represented as an array, such as ["4", "serves 4"]. I have not yet encountered a case where the number of servings is not at the first index of the array. Therefore, the function currently checks if yield is an array, and if so, it returns the first index.