### PR TITLE
scraper: include sub categories

### DIFF
--- a/src/components/IngredientsAndInstructionsToggle.tsx
+++ b/src/components/IngredientsAndInstructionsToggle.tsx
@@ -1,10 +1,38 @@
 "use client";
-import { Button, Group, List, Stack, Text } from "@mantine/core";
+import { Button, Group, List, Stack, Text, Title } from "@mantine/core";
 import { useState } from "react";
+import { render } from "react-dom";
 
 type IngAndInstToggleProps = {
   recipe: Recipe;
 };
+
+function renderInstructions(recipe) {
+  if (typeof recipe.instructions[0] === "string") {
+    return (
+      <List type="ordered" spacing="xs">
+        {recipe.instructions.map((instruction, index) => {
+          return <List.Item key={index}>{instruction}</List.Item>;
+        })}
+      </List>
+    );
+  } else if (typeof recipe.instructions[0] === "object") {
+    return (
+      <>
+        {recipe.instructions.map((section, sectionIndex) => (
+          <div key={sectionIndex}>
+            <Title order={3}>{section.name}</Title>
+            <List type="ordered" spacing="xs">
+              {section.text.map((instruction, index) => (
+                <List.Item key={index}>{instruction}</List.Item>
+              ))}
+            </List>
+          </div>
+        ))}
+      </>
+    );
+  }
+}
 
 export const IngredientsAndInstructionsToggle = ({
   recipe,
@@ -43,13 +71,7 @@ export const IngredientsAndInstructionsToggle = ({
           })}
         </List>
       )}
-      {view === "instructions" && (
-        <List type="ordered" spacing="xs">
-          {recipe.instructions.map((instruction, index) => {
-            return <List.Item key={index}>{instruction}</List.Item>;
-          })}
-        </List>
-      )}
+      {view === "instructions" && renderInstructions(recipe)}
     </Stack>
   );
 };

--- a/src/components/IngredientsAndInstructionsToggle.tsx
+++ b/src/components/IngredientsAndInstructionsToggle.tsx
@@ -1,38 +1,11 @@
 "use client";
 import { Button, Group, List, Stack, Text, Title } from "@mantine/core";
 import { useState } from "react";
-import { render } from "react-dom";
+import renderInstructions from "./RenderedInstructions";
 
 type IngAndInstToggleProps = {
   recipe: Recipe;
 };
-
-function renderInstructions(recipe) {
-  if (typeof recipe.instructions[0] === "string") {
-    return (
-      <List type="ordered" spacing="xs">
-        {recipe.instructions.map((instruction, index) => {
-          return <List.Item key={index}>{instruction}</List.Item>;
-        })}
-      </List>
-    );
-  } else if (typeof recipe.instructions[0] === "object") {
-    return (
-      <>
-        {recipe.instructions.map((section, sectionIndex) => (
-          <div key={sectionIndex}>
-            <Title order={3}>{section.name}</Title>
-            <List type="ordered" spacing="xs">
-              {section.text.map((instruction, index) => (
-                <List.Item key={index}>{instruction}</List.Item>
-              ))}
-            </List>
-          </div>
-        ))}
-      </>
-    );
-  }
-}
 
 export const IngredientsAndInstructionsToggle = ({
   recipe,

--- a/src/components/IngredientsAndInstructionsToggle.tsx
+++ b/src/components/IngredientsAndInstructionsToggle.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { Button, Group, List, Stack, Text, Title } from "@mantine/core";
+import { Button, Group, List, Stack, Text } from "@mantine/core";
 import { useState } from "react";
 import renderInstructions from "./RenderedInstructions";
 

--- a/src/components/RenderedInstructions.tsx
+++ b/src/components/RenderedInstructions.tsx
@@ -1,0 +1,32 @@
+import { List, Title } from "@mantine/core";
+
+export default function renderInstructions(recipe: Recipe) {
+  if (typeof recipe.instructions[0] === "string") {
+    return (
+      <List type="ordered" spacing="xs">
+        {recipe.instructions.map((instruction, index) => (
+          <List.Item key={index}>{instruction as string}</List.Item>
+        ))}
+      </List>
+    );
+  } else if (typeof recipe.instructions[0] === "object") {
+    return (
+      <>
+        {recipe.instructions.map((section, sectionIndex) => {
+          if (typeof section === "object" && "name" in section) {
+            return (
+              <div key={sectionIndex}>
+                <Title order={3}>{section.name}</Title>
+                <List type="ordered" spacing="xs">
+                  {section.text.map((instruction, index) => (
+                    <List.Item key={index}>{instruction}</List.Item>
+                  ))}
+                </List>
+              </div>
+            );
+          }
+        })}
+      </>
+    );
+  }
+}

--- a/src/lib/scraper.ts
+++ b/src/lib/scraper.ts
@@ -7,6 +7,7 @@ import {
   generateStringArray,
   getErrorMessage,
 } from "@/lib/utils";
+import he from "he";
 
 import { Browser, chromium, Page } from "playwright";
 
@@ -90,14 +91,10 @@ export const getScrapedRecipe = async (
       );
     }
 
-    type StructuredInstruction = {
-      name: string;
-      text: string[];
-    };
-
     const ingredientsData = recipeData.recipeIngredient;
-    let instructionsArray: ScrapedInstruction[];
-    let decodedInstructions: string[] | StructuredInstruction[] = [];
+    const decodedIngredients: Ingredient[] = decodeData(ingredientsData);
+    let instructionsArray: ScrapedInstruction[] = [];
+    let decodedInstructions: string[] | SectionInstruction[] = [];
 
     if (
       Array.isArray(recipeData.recipeInstructions) &&
@@ -127,15 +124,9 @@ export const getScrapedRecipe = async (
     ) {
       const sections = instructionsArray as HowToSection[];
       decodedInstructions = sections.map((section) => ({
-        name: section.name,
-        text: section.itemListElement.map((item) => item.text),
+        name: he.decode(section.name),
+        text: decodeData(section.itemListElement.map((item) => item.text)),
       }));
-
-      // const sections = instructionsArray as HowToSection[];
-      // sections.forEach((section) => {
-      //   const items = generateStringArray(section.itemListElement);
-      //   instructionsData.push(...items);
-      // });
 
       // case HowToStep:
     } else if (
@@ -152,8 +143,6 @@ export const getScrapedRecipe = async (
         "Oh no! The provided URL does not contain the necessary recipe data."
       );
     }
-
-    const decodedIngredients: Ingredient[] = decodeData(ingredientsData);
 
     console.log("decodedIngredients", decodedIngredients);
     console.log("decodedInstructions", decodedInstructions);

--- a/src/lib/types.d.ts
+++ b/src/lib/types.d.ts
@@ -2,13 +2,18 @@ type Ingredient = string;
 
 type Instruction = string;
 
+type SectionInstruction = {
+  name: string;
+  text: string[];
+};
+
 type Recipe = {
   title: string;
   author: string;
   time: string;
   yield: string;
   ingredients: Ingredient[];
-  instructions: Instruction[];
+  instructions: (Instruction | SectionInstruction)[];
 };
 
 type UserRecipe = {


### PR DESCRIPTION
This update implements a structured display for recipes that include sections in their instructions. When the recipe has sections, each section name is rendered as a title, with the corresponding steps listed beneath it. 

**Note:** This solution requires further validation to ensure compatibility with various types of recipes. Additionally, recipes with this structure cannot currently be saved, as they do not follow to the expected schema.