### PR TITLE
feat: add repeat password field

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -4,16 +4,18 @@ import Link from "next/link";
 
 export default function Login() {
   return (
-    <Container style={{ height: "90dvh", alignContent: "center" }}>
-      <Title ta="center" mb="md">
-        Log in
+    <Container my="4rem">
+      <Title ta="center" mb="xl" size={"2rem"}>
+        Welcome back!
       </Title>
+
       <LoginForm />
-      <Text ta="center">
+
+      <Text ta="center" mt="md">
         Don&apos;t have an account?{" "}
         <span>
-          <Anchor component={Link} href="/signup" underline="never">
-            Create account
+          <Anchor component={Link} href="/signup" fw="bold">
+            Create one
           </Anchor>
         </span>
       </Text>

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -5,15 +5,15 @@ import Link from "next/link";
 export default function SignUp() {
   return (
     <>
-      <Container style={{ height: "90dvh", alignContent: "center" }}>
-        <Title ta="center" mb="md">
-          Create account
+      <Container my="4rem">
+        <Title ta="center" mb="xl" size={"2rem"}>
+          Welcome to Recipe Declutter!
         </Title>
         <SignUpForm />
-        <Text ta="center">
+        <Text ta="center" mt="md">
           Already have an account?{" "}
           <span>
-            <Anchor component={Link} href="/login" underline="never">
+            <Anchor component={Link} href="/login" fw="bold">
               Log in
             </Anchor>
           </span>

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -7,7 +7,8 @@ import {
   Button,
   Alert,
   PasswordInput,
-  LoadingOverlay,
+  Stack,
+  Paper,
 } from "@mantine/core";
 import { isEmail, useForm } from "@mantine/form";
 
@@ -44,7 +45,6 @@ export default function LoginForm() {
       if (result?.error) {
         setError("Invalid email or password. Please try again.");
       } else {
-        form.reset(); // Reset form only if submission was successful
         router.push("/welcome"); // Redirect to landing page
       }
     } catch (error: unknown) {
@@ -60,42 +60,42 @@ export default function LoginForm() {
 
   return (
     <>
-      <form onSubmit={form.onSubmit(submitCredentials)}>
-        <LoadingOverlay visible={loading} overlayProps={{ blur: 3 }} />
+      <Paper
+        radius="md"
+        p={{ base: "md", sm: "xl" }}
+        withBorder
+        shadow="md"
+        maw="30rem"
+        mx="auto"
+      >
+        <form onSubmit={form.onSubmit(submitCredentials)}>
+          <Stack>
+            {error && (
+              <Alert variant="light" color="red" title="Sign up failed">
+                {error}
+              </Alert>
+            )}
+            <TextInput
+              {...form.getInputProps("email")}
+              key={form.key("email")}
+              label="Email"
+              placeholder="your@email.com"
+              disabled={loading}
+            />
+            <PasswordInput
+              {...form.getInputProps("password")}
+              key={form.key("password")}
+              label="Password"
+              placeholder="Your password"
+              disabled={loading}
+            />
 
-        {error && (
-          <Alert variant="light" color="red" title="Login failed" mt="md">
-            {error}
-          </Alert>
-        )}
-        <TextInput
-          {...form.getInputProps("email")}
-          key={form.key("email")}
-          mt="md"
-          label="Email"
-          placeholder="your@email.com"
-          disabled={loading}
-        />
-        <PasswordInput
-          {...form.getInputProps("password")}
-          key={form.key("password")}
-          mt="md"
-          label="Password"
-          placeholder="••••••"
-          disabled={loading}
-        />
-        <Button
-          type="submit"
-          mt="xl"
-          mb="md"
-          fullWidth
-          variant="filled"
-          size="md"
-          disabled={loading}
-        >
-          Submit
-        </Button>
-      </form>
+            <Button type="submit" mt="md" variant="filled" loading={loading}>
+              Log in
+            </Button>
+          </Stack>
+        </form>
+      </Paper>
     </>
   );
 }

--- a/src/components/SignUpForm.tsx
+++ b/src/components/SignUpForm.tsx
@@ -4,8 +4,10 @@ import { useRouter } from "next/navigation";
 import {
   Alert,
   Button,
-  LoadingOverlay,
+  Checkbox,
+  Paper,
   PasswordInput,
+  Stack,
   TextInput,
 } from "@mantine/core";
 import { hasLength, isEmail, useForm } from "@mantine/form";
@@ -14,6 +16,7 @@ type UserData = {
   email: string;
   name: string;
   password: string;
+  accepted: boolean;
 };
 
 export default function SignUpForm() {
@@ -24,11 +27,21 @@ export default function SignUpForm() {
 
   const form = useForm({
     mode: "uncontrolled",
-    initialValues: { name: "", email: "", password: "" },
+    initialValues: {
+      name: "",
+      email: "",
+      password: "",
+      confirmPassword: "",
+      accepted: false,
+    },
     validate: {
       name: hasLength({ min: 3 }, "Must be at least 3 characters"),
       email: isEmail("Invalid email"),
       password: hasLength({ min: 8 }, "Must be at least 8 characters"),
+      confirmPassword: (value, values) =>
+        value !== values.password ? "Passwords did not match" : null,
+      accepted: (value) =>
+        value ? null : "You must accept terms and conditions",
     },
   });
 
@@ -48,7 +61,6 @@ export default function SignUpForm() {
       if (!res.ok) {
         throw new Error(data.message);
       }
-      form.reset(); // Reset form only if submission was successful
       router.push("/login"); // Redirect to login
     } catch (error: unknown) {
       if (error instanceof Error) {
@@ -62,48 +74,60 @@ export default function SignUpForm() {
   };
 
   return (
-    <form onSubmit={form.onSubmit(submitUserData)}>
-      <LoadingOverlay visible={loading} overlayProps={{ blur: 3 }} />
-
-      {error && (
-        <Alert variant="light" color="red" title="Sign up failed" mb="md">
-          {error}
-        </Alert>
-      )}
-      <TextInput
-        {...form.getInputProps("name")}
-        key={form.key("name")}
-        label="Name"
-        placeholder="Your name"
-        disabled={loading}
-      />
-      <TextInput
-        {...form.getInputProps("email")}
-        key={form.key("email")}
-        mt="md"
-        label="Email"
-        placeholder="your@email.com"
-        disabled={loading}
-      />
-      <PasswordInput
-        {...form.getInputProps("password")}
-        key={form.key("password")}
-        mt="md"
-        label="Password"
-        placeholder="••••••"
-        disabled={loading}
-      />
-      <Button
-        type="submit"
-        mt="xl"
-        mb="md"
-        fullWidth
-        variant="filled"
-        size="md"
-        disabled={loading}
-      >
-        Submit
-      </Button>
-    </form>
+    <Paper
+      radius="md"
+      p={{ base: "md", sm: "xl" }}
+      withBorder
+      shadow="md"
+      maw="30rem"
+      mx="auto"
+    >
+      <form onSubmit={form.onSubmit(submitUserData)}>
+        <Stack>
+          {error && (
+            <Alert variant="light" color="red" title="Sign up failed">
+              {error}
+            </Alert>
+          )}
+          <TextInput
+            {...form.getInputProps("name")}
+            key={form.key("name")}
+            label="Name"
+            placeholder="Your name"
+            disabled={loading}
+          />
+          <TextInput
+            {...form.getInputProps("email")}
+            key={form.key("email")}
+            label="Email"
+            placeholder="your@email.com"
+            disabled={loading}
+          />
+          <PasswordInput
+            {...form.getInputProps("password")}
+            key={form.key("password")}
+            label="Password"
+            placeholder="Your password"
+            disabled={loading}
+          />
+          <PasswordInput
+            {...form.getInputProps("confirmPassword")}
+            key={form.key("confirmPassword")}
+            label="Confirm Password"
+            placeholder="Confirm your password"
+            disabled={loading}
+          />
+          {/* add popup with some simple t&c */}
+          <Checkbox
+            key={form.key("accepted")}
+            {...form.getInputProps("accepted", { type: "checkbox" })}
+            label="I accept terms and conditions"
+          />
+          <Button type="submit" mt="md" variant="filled" loading={loading}>
+            Create account
+          </Button>
+        </Stack>
+      </form>
+    </Paper>
   );
 }


### PR DESCRIPTION
This PR updates `/signnup` and `/login` and their respective form components

- add max width and box with border
- change title font size
- change copy here and there
- add confirm password field and validation
- add terms acceptance field and validation
- update loading solution - spinner overlay -> spinner on button

The loading glitch (#119) is also *almost* gone with this update but requires a bit more care.