### PR TITLE
feat: refactor edit form

### DIFF
--- a/src/components/EditIngredientsAndInstructionsLists.tsx
+++ b/src/components/EditIngredientsAndInstructionsLists.tsx
@@ -12,17 +12,17 @@ import {
 import { IconPlus, IconTrash } from "@tabler/icons-react";
 import { UseFormReturnType } from "@mantine/form";
 
-type IngredientAndInstructionListProps = {
+type EditIngredientAndInstructionListProps = {
   form: UseFormReturnType<FormValues>;
   hasSections: boolean;
   view: "ingredients" | "instructions";
 };
 
-export const IngredientAndInstructionList = ({
+export const EditIngredientAndInstructionList = ({
   form,
   hasSections,
   view,
-}: IngredientAndInstructionListProps) => {
+}: EditIngredientAndInstructionListProps) => {
   // Add/remove functions for ingredients
   const addIngredient = () => form.insertListItem("ingredients", "");
   const removeIngredient = (index: number) =>

--- a/src/components/EditIngredientsAndInstructionsLists.tsx
+++ b/src/components/EditIngredientsAndInstructionsLists.tsx
@@ -1,0 +1,203 @@
+import React from "react";
+import {
+  Fieldset,
+  Group,
+  ActionIcon,
+  Button,
+  Textarea,
+  TextInput,
+  Card,
+  Divider,
+} from "@mantine/core";
+import { IconPlus, IconTrash } from "@tabler/icons-react";
+import { UseFormReturnType } from "@mantine/form";
+
+type IngredientAndInstructionListProps = {
+  form: UseFormReturnType<FormValues>;
+  hasSections: boolean;
+  view: "ingredients" | "instructions";
+};
+
+export const IngredientAndInstructionList = ({
+  form,
+  hasSections,
+  view,
+}: IngredientAndInstructionListProps) => {
+  // Add/remove functions for ingredients
+  const addIngredient = () => form.insertListItem("ingredients", "");
+  const removeIngredient = (index: number) =>
+    form.removeListItem("ingredients", index);
+
+  // Add/remove functions for sectioned instructions
+  const removeSection = (sectionIndex: number) => {
+    if (hasSections) {
+      form.removeListItem("instructions", sectionIndex);
+    }
+  };
+  const addInstruction = (sectionIndex: number) => {
+    if (hasSections) {
+      form.insertListItem(`instructions.${sectionIndex}.text`, "");
+    }
+  };
+  const removeInstruction = (
+    sectionIndex: number,
+    instructionIndex: number
+  ) => {
+    if (hasSections) {
+      form.removeListItem(
+        `instructions.${sectionIndex}.text`,
+        instructionIndex
+      );
+    }
+  };
+
+  // Add/remove functions for simple instructions
+  const addSimpleInstruction = () => {
+    if (!hasSections) {
+      form.insertListItem("instructions", "");
+    }
+  };
+  const removeSimpleInstruction = (index: number) => {
+    if (!hasSections) {
+      form.removeListItem("instructions", index);
+    }
+  };
+
+  return (
+    <>
+      {view === "ingredients" && (
+        <Fieldset mb="md" legend="Ingredients">
+          {form.values.ingredients.map((_ingredient: string, index: number) => (
+            <Group wrap="nowrap" key={index} mt="xs" align="flex-start">
+              <TextInput
+                style={{ width: "100%" }}
+                placeholder={`Ingredient ${index + 1}`}
+                {...form.getInputProps(`ingredients.${index}`)}
+              />
+              <ActionIcon
+                onClick={() => removeIngredient(index)}
+                variant="transparent"
+                aria-label="Delete ingredient"
+              >
+                <IconTrash />
+              </ActionIcon>
+            </Group>
+          ))}
+          <Button
+            leftSection={<IconPlus size={14} />}
+            onClick={addIngredient}
+            variant="light"
+            mt="md"
+            aria-label="Add ingredient"
+          >
+            Add ingredient
+          </Button>
+        </Fieldset>
+      )}
+      {view === "instructions" && (
+        <Fieldset mb="md" legend="Instructions">
+          {/* If sectioned instructions */}
+          {hasSections ? (
+            <>
+              {(form.values.instructions as SectionInstruction[]).map(
+                (section, sectionIndex) => (
+                  <Card key={sectionIndex} withBorder mb="md">
+                    <Group wrap="nowrap" align="flex-start">
+                      <TextInput
+                        label="Section title"
+                        style={{ width: "100%" }}
+                        placeholder="Section title"
+                        {...form.getInputProps(
+                          `instructions.${sectionIndex}.name`
+                        )}
+                      />
+                      <ActionIcon
+                        onClick={() => removeSection(sectionIndex)}
+                        variant="transparent"
+                        aria-label="Delete section"
+                      >
+                        <IconTrash />
+                      </ActionIcon>
+                    </Group>
+
+                    <Divider my="sm" />
+
+                    {section.text.map((_instruction, instructionIndex) => (
+                      <Group
+                        wrap="nowrap"
+                        key={instructionIndex}
+                        mt="xs"
+                        align="flex-start"
+                      >
+                        <Textarea
+                          style={{ width: "100%" }}
+                          placeholder={`Step ${instructionIndex + 1}`}
+                          minRows={3}
+                          {...form.getInputProps(
+                            `instructions.${sectionIndex}.text.${instructionIndex}`
+                          )}
+                        />
+                        <ActionIcon
+                          onClick={() =>
+                            removeInstruction(sectionIndex, instructionIndex)
+                          }
+                          variant="transparent"
+                          aria-label="Delete instruction"
+                        >
+                          <IconTrash />
+                        </ActionIcon>
+                      </Group>
+                    ))}
+
+                    <Button
+                      leftSection={<IconPlus size={14} />}
+                      onClick={() => addInstruction(sectionIndex)}
+                      variant="light"
+                      size="sm"
+                      mt="md"
+                      aria-label="Add instruction"
+                    >
+                      Add step
+                    </Button>
+                  </Card>
+                )
+              )}
+            </>
+          ) : (
+            <>
+              {/* If simple instructions list*/}
+              {(form.values.instructions as string[]).map(
+                (instruction, index) => (
+                  <Group wrap="nowrap" key={index} mt="xs" align="flex-start">
+                    <Textarea
+                      style={{ width: "100%" }}
+                      placeholder={`Step ${index + 1}`}
+                      minRows={3}
+                      {...form.getInputProps(`instructions.${index}`)}
+                    />
+                    <ActionIcon
+                      onClick={() => removeSimpleInstruction(index)}
+                      variant="transparent"
+                      aria-label="Delete instruction"
+                    >
+                      <IconTrash />
+                    </ActionIcon>
+                  </Group>
+                )
+              )}
+              <Button
+                leftSection={<IconPlus size={14} />}
+                onClick={addSimpleInstruction}
+                variant="light"
+                mt="md"
+                aria-label="Add instruction"
+              >
+                Add instruction
+              </Button>
+            </>
+          )}
+        </Fieldset>
+      )}
+    </>
+  );
+};

--- a/src/components/EditRecipeForm.tsx
+++ b/src/components/EditRecipeForm.tsx
@@ -15,7 +15,7 @@ import {
 import { useForm } from "@mantine/form";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
-import { IngredientAndInstructionList } from "./EditIngredientsAndInstructionsLists";
+import { EditIngredientAndInstructionList } from "./EditIngredientsAndInstructionsLists";
 
 type EditRecipeProps = {
   recipe: UserRecipe;
@@ -129,7 +129,7 @@ export const EditRecipeForm = ({ recipe }: EditRecipeProps) => {
         </Group>
 
         {/* Ingredients and Instructions */}
-        <IngredientAndInstructionList
+        <EditIngredientAndInstructionList
           form={form}
           hasSections={hasSections}
           view={view}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -76,3 +76,25 @@ export function convertTime(duration: string) {
     }`.trim() || "0 min"
   );
 }
+
+export function isSectionedInstruction(
+  instructions: Instructions
+): instructions is SectionedInstructions {
+  return (
+    Array.isArray(instructions) &&
+    instructions.length > 0 &&
+    typeof instructions[0] === "object" &&
+    instructions[0] !== null &&
+    "name" in instructions[0] &&
+    "text" in instructions[0]
+  );
+}
+
+export function isSimpleInstruction(
+  instructions: Instructions
+): instructions is SimpleInstructions {
+  return (
+    Array.isArray(instructions) &&
+    (instructions.length === 0 || typeof instructions[0] === "string")
+  );
+}


### PR DESCRIPTION
The goal with this PR was to make the EditRecipeForm a bit easier to read and manage. What I have done so far:
- [x] Moved the handling of ingredients and instructions (add/remove functionality, rendering logic) into the IngredientAndInstructionList component. 
- [x] The utility functions (isSectionedInstruction, isSimpleInstruction) have been moved to the utils.ts file.

The code is still pretty lenghty, and maybe more can be done to make it cleaner.