### PR TITLE
fix: overflow on ingredients/instructions lists

### DIFF
--- a/src/components/IngredientsAndInstructionsToggle.tsx
+++ b/src/components/IngredientsAndInstructionsToggle.tsx
@@ -43,7 +43,18 @@ export const IngredientsAndInstructionsToggle = ({
       {view === "ingredients" && (
         <List>
           {recipe.ingredients.map((ingredient, index) => {
-            return <List.Item key={index}>{ingredient}</List.Item>;
+            return (
+              <List.Item
+                styles={{
+                  itemWrapper: {
+                    display: "inline",
+                  },
+                }}
+                key={index}
+              >
+                {ingredient}
+              </List.Item>
+            );
           })}
         </List>
       )}

--- a/src/components/RenderedInstructions.tsx
+++ b/src/components/RenderedInstructions.tsx
@@ -9,7 +9,16 @@ export default function RenderedInstructions({ recipe }: RenderProps) {
     return (
       <List type="ordered" spacing="xs">
         {recipe.instructions.map((instruction, index) => (
-          <List.Item key={index}>{instruction as string}</List.Item>
+          <List.Item
+            styles={{
+              itemWrapper: {
+                display: "inline",
+              },
+            }}
+            key={index}
+          >
+            {instruction as string}
+          </List.Item>
         ))}
       </List>
     );
@@ -23,7 +32,16 @@ export default function RenderedInstructions({ recipe }: RenderProps) {
                 <Title order={3}>{section.name}</Title>
                 <List type="ordered" spacing="xs">
                   {section.text.map((instruction: string, index: number) => (
-                    <List.Item key={index}>{instruction}</List.Item>
+                    <List.Item
+                      styles={{
+                        itemWrapper: {
+                          display: "inline",
+                        },
+                      }}
+                      key={index}
+                    >
+                      {instruction}
+                    </List.Item>
                   ))}
                 </List>
               </div>


### PR DESCRIPTION
This PR fixes the overflow bug by overriding default Mantine List.Item styles