### PR TITLE
feat: dropdown for account links

### DIFF
--- a/src/components/Header/AccountDropdown.tsx
+++ b/src/components/Header/AccountDropdown.tsx
@@ -1,0 +1,58 @@
+import { Anchor, Menu, rem } from "@mantine/core";
+import { IconSettings, IconLogout2, IconNotebook } from "@tabler/icons-react";
+import { LoginButton } from "../LogInButton";
+import { Session } from "next-auth";
+import Link from "next/link";
+import { signOut } from "next-auth/react";
+
+type AccountDropdownProps = {
+  session: Session | null;
+};
+
+export default function AccountDropdown({ session }: AccountDropdownProps) {
+  if (!session) {
+    return (
+      <Link href="/login" passHref>
+        <LoginButton session={session} />
+      </Link>
+    );
+  }
+  return (
+    <Menu shadow="md" width={200}>
+      <Menu.Target>
+        <LoginButton session={session} />
+      </Menu.Target>
+      <Menu.Dropdown>
+        <Menu.Label>My Account</Menu.Label>
+        <Menu.Item
+          component={Link}
+          href="/dashboard"
+          leftSection={
+            <IconNotebook style={{ width: rem(18), height: rem(18) }} />
+          }
+        >
+          My recipes
+        </Menu.Item>
+        <Menu.Item
+          component={Link}
+          href="#"
+          leftSection={
+            <IconSettings style={{ width: rem(18), height: rem(18) }} />
+          }
+        >
+          Settings
+        </Menu.Item>
+
+        <Menu.Divider />
+        <Menu.Item
+          onClick={() => signOut({ callbackUrl: "/login" })}
+          leftSection={
+            <IconLogout2 style={{ width: rem(18), height: rem(18) }} />
+          }
+        >
+          Log out
+        </Menu.Item>
+      </Menu.Dropdown>
+    </Menu>
+  );
+}

--- a/src/components/Header/AccountDropdown.tsx
+++ b/src/components/Header/AccountDropdown.tsx
@@ -10,13 +10,6 @@ type AccountDropdownProps = {
 };
 
 export default function AccountDropdown({ session }: AccountDropdownProps) {
-  if (!session) {
-    return (
-      <Link href="/login" passHref>
-        <LoginButton session={session} />
-      </Link>
-    );
-  }
   return (
     <Menu shadow="md" width={200}>
       <Menu.Target>

--- a/src/components/Header/Navbar.tsx
+++ b/src/components/Header/Navbar.tsx
@@ -4,8 +4,8 @@ import { useState } from "react";
 import { Container, Burger, Anchor, Text, Paper, Stack } from "@mantine/core";
 import { useClickOutside, useDisclosure } from "@mantine/hooks";
 import Link from "next/link";
-import { LoginButton } from "../LogInButton";
 import { useSession } from "next-auth/react";
+import AccountDropdown from "./AccountDropdown";
 
 export const Navbar = () => {
   const { data: session } = useSession();
@@ -36,7 +36,7 @@ export const Navbar = () => {
             Recipe Declutter
           </Text>
         </Anchor>
-        <LoginButton session={session} />
+        <AccountDropdown session={session} />
 
         {opened && (
           <Paper

--- a/src/components/Header/Navbar.tsx
+++ b/src/components/Header/Navbar.tsx
@@ -5,8 +5,8 @@ import { Container, Burger, Anchor, Text, Paper, Stack } from "@mantine/core";
 import { useClickOutside, useDisclosure } from "@mantine/hooks";
 import Link from "next/link";
 import { useSession } from "next-auth/react";
-import AccountDropdown from "./AccountDropdown";
 import { LoginButton } from "../LogInButton";
+import UserMenu from "./UserMenu";
 
 export const Navbar = () => {
   const { data: session } = useSession();
@@ -41,10 +41,12 @@ export const Navbar = () => {
         {/* Different button depending on whether the user is logged in or not */}
         {!session ? (
           <Link href="/login" passHref>
-            <LoginButton session={session} />
+            <LoginButton displayName="Log in" />
           </Link>
         ) : (
-          <AccountDropdown session={session} />
+          <UserMenu
+            displayName={session.user.name?.charAt(0).toUpperCase() || "U"}
+          />
         )}
 
         {opened && (

--- a/src/components/Header/Navbar.tsx
+++ b/src/components/Header/Navbar.tsx
@@ -5,7 +5,7 @@ import { Container, Burger, Anchor, Text, Paper, Stack } from "@mantine/core";
 import { useClickOutside, useDisclosure } from "@mantine/hooks";
 import Link from "next/link";
 import { useSession } from "next-auth/react";
-import { LoginButton } from "../LogInButton";
+import { UserButton } from "../LogInButton";
 import UserMenu from "./UserMenu";
 
 export const Navbar = () => {
@@ -41,7 +41,7 @@ export const Navbar = () => {
         {/* Different button depending on whether the user is logged in or not */}
         {!session ? (
           <Link href="/login" passHref>
-            <LoginButton displayName="Log in" />
+            <UserButton displayName="Log in" />
           </Link>
         ) : (
           <UserMenu

--- a/src/components/Header/Navbar.tsx
+++ b/src/components/Header/Navbar.tsx
@@ -6,6 +6,7 @@ import { useClickOutside, useDisclosure } from "@mantine/hooks";
 import Link from "next/link";
 import { useSession } from "next-auth/react";
 import AccountDropdown from "./AccountDropdown";
+import { LoginButton } from "../LogInButton";
 
 export const Navbar = () => {
   const { data: session } = useSession();
@@ -31,12 +32,20 @@ export const Navbar = () => {
     >
       <Container {...containerProps} size="md">
         <Burger color="cream.0" opened={opened} onClick={toggle} size="sm" />
+
         <Anchor component={Link} href="/" underline="never">
           <Text c="cream.0" fw={500}>
             Recipe Declutter
           </Text>
         </Anchor>
-        <AccountDropdown session={session} />
+        {/* Different button depending on whether the user is logged in or not */}
+        {!session ? (
+          <Link href="/login" passHref>
+            <LoginButton session={session} />
+          </Link>
+        ) : (
+          <AccountDropdown session={session} />
+        )}
 
         {opened && (
           <Paper

--- a/src/components/Header/UserMenu.tsx
+++ b/src/components/Header/UserMenu.tsx
@@ -1,6 +1,6 @@
 import { Menu, rem } from "@mantine/core";
 import { IconSettings, IconLogout2, IconNotebook } from "@tabler/icons-react";
-import { LoginButton } from "../LogInButton";
+import { UserButton } from "../LogInButton";
 import Link from "next/link";
 import { signOut } from "next-auth/react";
 
@@ -12,7 +12,7 @@ export default function UserMenu({ displayName }: UserMenuProps) {
   return (
     <Menu shadow="md" width={200}>
       <Menu.Target>
-        <LoginButton displayName={displayName} isLoggedIn={true} />
+        <UserButton displayName={displayName} isLoggedIn={true} />
       </Menu.Target>
       <Menu.Dropdown>
         <Menu.Label>My Account</Menu.Label>

--- a/src/components/Header/UserMenu.tsx
+++ b/src/components/Header/UserMenu.tsx
@@ -1,19 +1,18 @@
-import { Anchor, Menu, rem } from "@mantine/core";
+import { Menu, rem } from "@mantine/core";
 import { IconSettings, IconLogout2, IconNotebook } from "@tabler/icons-react";
 import { LoginButton } from "../LogInButton";
-import { Session } from "next-auth";
 import Link from "next/link";
 import { signOut } from "next-auth/react";
 
-type AccountDropdownProps = {
-  session: Session | null;
+type UserMenuProps = {
+  displayName: string;
 };
 
-export default function AccountDropdown({ session }: AccountDropdownProps) {
+export default function UserMenu({ displayName }: UserMenuProps) {
   return (
     <Menu shadow="md" width={200}>
       <Menu.Target>
-        <LoginButton session={session} />
+        <LoginButton displayName={displayName} isLoggedIn={true} />
       </Menu.Target>
       <Menu.Dropdown>
         <Menu.Label>My Account</Menu.Label>

--- a/src/components/LogInButton.tsx
+++ b/src/components/LogInButton.tsx
@@ -1,33 +1,36 @@
 import { Button } from "@mantine/core";
 import { IconUser } from "@tabler/icons-react";
 import { Session } from "next-auth";
-import Link from "next/link";
+import React, { forwardRef } from "react";
 
 type LoginButtonProps = {
-  session?: Session | null;
-};
+  session: Session | null;
+} & React.ComponentPropsWithoutRef<"button">;
 
-export const LoginButton = ({ session }: LoginButtonProps) => {
-  const displayName = session
-    ? session.user.name?.charAt(0).toUpperCase()
-    : "Log in";
+export const LoginButton = forwardRef<HTMLButtonElement, LoginButtonProps>(
+  ({ session, ...props }, ref) => {
+    const displayName = session
+      ? session.user.name?.charAt(0).toUpperCase()
+      : "Log in";
 
-  return (
-    <Button
-      href={session ? "/dashboard" : "/login"}
-      component={Link}
-      color="cream.0"
-      size="xs"
-      justify="center"
-      leftSection={<IconUser size={20} stroke={1.5} />}
-      variant={session ? "filled" : "light"}
-      styles={{
-        root: {
-          color: session ? "var(--mantine-color-dustyRed-7)" : undefined, // Custom font color if logged in
-        },
-      }}
-    >
-      {displayName}
-    </Button>
-  );
-};
+    return (
+      <Button
+        ref={ref}
+        color="cream.0"
+        size="xs"
+        justify="center"
+        leftSection={<IconUser size={20} stroke={1.5} />}
+        variant={session ? "filled" : "light"}
+        styles={{
+          root: {
+            color: session ? "var(--mantine-color-dustyRed-7)" : undefined, // Custom font color if logged in
+          },
+        }}
+        {...props}
+      >
+        {displayName}
+      </Button>
+    );
+  }
+);
+LoginButton.displayName = "LoginButton";

--- a/src/components/LogInButton.tsx
+++ b/src/components/LogInButton.tsx
@@ -1,18 +1,14 @@
 import { Button } from "@mantine/core";
 import { IconUser } from "@tabler/icons-react";
-import { Session } from "next-auth";
 import React, { forwardRef } from "react";
 
 type LoginButtonProps = {
-  session: Session | null;
+  displayName: string;
+  isLoggedIn?: boolean;
 } & React.ComponentPropsWithoutRef<"button">;
 
 export const LoginButton = forwardRef<HTMLButtonElement, LoginButtonProps>(
-  ({ session, ...props }, ref) => {
-    const displayName = session
-      ? session.user.name?.charAt(0).toUpperCase()
-      : "Log in";
-
+  ({ displayName, isLoggedIn = false, ...props }, ref) => {
     return (
       <Button
         ref={ref}
@@ -20,10 +16,10 @@ export const LoginButton = forwardRef<HTMLButtonElement, LoginButtonProps>(
         size="xs"
         justify="center"
         leftSection={<IconUser size={20} stroke={1.5} />}
-        variant={session ? "filled" : "light"}
+        variant={isLoggedIn ? "filled" : "light"}
         styles={{
           root: {
-            color: session ? "var(--mantine-color-dustyRed-7)" : undefined, // Custom font color if logged in
+            color: isLoggedIn ? "var(--mantine-color-dustyRed-7)" : undefined, // Custom font color if logged in
           },
         }}
         {...props}

--- a/src/components/LogInButton.tsx
+++ b/src/components/LogInButton.tsx
@@ -2,12 +2,12 @@ import { Button } from "@mantine/core";
 import { IconUser } from "@tabler/icons-react";
 import React, { forwardRef } from "react";
 
-type LoginButtonProps = {
+type UserButtonProps = {
   displayName: string;
   isLoggedIn?: boolean;
 } & React.ComponentPropsWithoutRef<"button">;
 
-export const LoginButton = forwardRef<HTMLButtonElement, LoginButtonProps>(
+export const UserButton = forwardRef<HTMLButtonElement, UserButtonProps>(
   ({ displayName, isLoggedIn = false, ...props }, ref) => {
     return (
       <Button
@@ -29,4 +29,4 @@ export const LoginButton = forwardRef<HTMLButtonElement, LoginButtonProps>(
     );
   }
 );
-LoginButton.displayName = "LoginButton";
+UserButton.displayName = "LoginButton";


### PR DESCRIPTION
- [x] If a user is logged in, the account button is now a dropdown with links for "my recipe", "settings" and "log out"
- [x] When not logged in it remains as a link to ``/login``

**To do:**
- [ ] Make burger dropdown and account dropdown look the same
- [x] Consider changing name of the LogInButton to something like "AuthButton" (just an example), since it is also used when a user is logged in (=not a login button anymore)?