### PR TITLE
fix: form focus zoom bug in Safari on iOS - option 1

### DIFF
--- a/src/app/theme.ts
+++ b/src/app/theme.ts
@@ -1,5 +1,4 @@
 import { createTheme } from "@mantine/core";
-
 import { Poppins } from "next/font/google";
 
 const poppins = Poppins({
@@ -57,5 +56,32 @@ export const theme = createTheme({
 
   headings: {
     fontFamily: `${poppins.style.fontFamily}, sans-serif`,
+  },
+  components: {
+    Input: {
+      defaultProps: {
+        size: "md",
+      },
+    },
+    TextInput: {
+      defaultProps: {
+        size: "md",
+      },
+    },
+    PasswordInput: {
+      defaultProps: {
+        size: "md",
+      },
+    },
+    MultiSelect: {
+      defaultProps: {
+        size: "md",
+      },
+    },
+    Button: {
+      defaultProps: {
+        size: "md",
+      },
+    },
   },
 });


### PR DESCRIPTION
There seems to be two options to fix this bug. 

One is to not use a font size smaller than 16px in form fields, since this is what iOS on Safari zooms in to if fields use a smaller font size.

This PR solves the issue by changing default props of all form element components in question (plus the button for consistency) to size "md" - which corresponds to 16px.

Personally I think they look to large on mobile like this but in terms of accessibility it's probably good to keep it (since this is probably why the iPhones do the zoom in thing in the first place)...