### PR TITLE
fix: form focus zoom bug in Safari on iOS - option 2

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -24,6 +24,10 @@ export default function RootLayout({
           nonce="8IBTHwOdqNKAWeKl7plt8g=="
           defaultColorScheme="auto"
         />
+        <meta
+          name="viewport"
+          content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0"
+        />
       </head>
       <body style={{ height: "100dvh" }}>
         <MantineProvider defaultColorScheme="auto" theme={theme}>

--- a/src/app/theme.ts
+++ b/src/app/theme.ts
@@ -1,5 +1,4 @@
 import { createTheme } from "@mantine/core";
-
 import { Poppins } from "next/font/google";
 
 const poppins = Poppins({
@@ -57,5 +56,32 @@ export const theme = createTheme({
 
   headings: {
     fontFamily: `${poppins.style.fontFamily}, sans-serif`,
+  },
+  components: {
+    Input: {
+      defaultProps: {
+        size: "md",
+      },
+    },
+    TextInput: {
+      defaultProps: {
+        size: "md",
+      },
+    },
+    PasswordInput: {
+      defaultProps: {
+        size: "md",
+      },
+    },
+    MultiSelect: {
+      defaultProps: {
+        size: "md",
+      },
+    },
+    Button: {
+      defaultProps: {
+        size: "md",
+      },
+    },
   },
 });

--- a/src/app/theme.ts
+++ b/src/app/theme.ts
@@ -57,31 +57,4 @@ export const theme = createTheme({
   headings: {
     fontFamily: `${poppins.style.fontFamily}, sans-serif`,
   },
-  components: {
-    Input: {
-      defaultProps: {
-        size: "md",
-      },
-    },
-    TextInput: {
-      defaultProps: {
-        size: "md",
-      },
-    },
-    PasswordInput: {
-      defaultProps: {
-        size: "md",
-      },
-    },
-    MultiSelect: {
-      defaultProps: {
-        size: "md",
-      },
-    },
-    Button: {
-      defaultProps: {
-        size: "md",
-      },
-    },
-  },
 });


### PR DESCRIPTION
There seems to be two options to fix this bug.

One is to add a meta tag which sets both the initial scale and maximum scale of the viewport to 100% which allegedly will disable the zoom bug.

The drawback of this approach is that we're disabling the users ability to zoom at all which can be an accessibility concern ( if someone for example needs to zoom in to read some text they wouldn't be able to do so).  