### PR TITLE
add defaultProps for TagsInput and Textarea

### DIFF
--- a/src/app/theme.ts
+++ b/src/app/theme.ts
@@ -78,6 +78,16 @@ export const theme = createTheme({
         size: "md",
       },
     },
+    TagsInput: {
+      defaultProps: {
+        size: "md",
+      },
+    },
+    Textarea: {
+      defaultProps: {
+        size: "md",
+      },
+    },
     Button: {
       defaultProps: {
         size: "md",


### PR DESCRIPTION
Related to the iOS bug where text in form fields needed to be at least 16px.

This PR makes sure that all form fields we use have default size "md" (TagsInput and Textarea were missed in the iOS bug PR)