### PR TITLE
feat: improve ux of input fields in edit recipe page

### DIFF
--- a/src/components/DeleteButtonDropdown.tsx
+++ b/src/components/DeleteButtonDropdown.tsx
@@ -1,0 +1,46 @@
+import { ActionIcon, Menu } from "@mantine/core";
+import { IconTrash } from "@tabler/icons-react";
+
+interface DeleteButtonDropdownProps {
+  onClickDelete: () => void;
+  type: string;
+}
+
+const DeleteButtonDropdown = ({
+  onClickDelete,
+  type,
+}: DeleteButtonDropdownProps) => {
+  return (
+    <Menu.Dropdown
+      bg={"none"}
+      style={{
+        border: "none",
+      }}
+    >
+      <Menu.Item
+        aria-label="Delete this instruction"
+        styles={{
+          item: {
+            backgroundColor: "transparent",
+            "&:hover": {
+              backgroundColor: "transparent",
+            },
+          },
+        }}
+      >
+        <ActionIcon
+          // line below needed since both Menu.Item and ActionIcon renders a button (a button in a button is not valid HTML )
+          component="div"
+          onClick={onClickDelete}
+          variant="filled"
+          aria-label={`Delete ${type}`}
+          size={"lg"}
+        >
+          <IconTrash size={20} stroke={1.5} />
+        </ActionIcon>
+      </Menu.Item>
+    </Menu.Dropdown>
+  );
+};
+
+export default DeleteButtonDropdown;

--- a/src/components/EditIngredientsList.tsx
+++ b/src/components/EditIngredientsList.tsx
@@ -1,26 +1,14 @@
 import React from "react";
-import {
-  Fieldset,
-  Group,
-  Button,
-  TextInput,
-  Menu,
-  Flex,
-  ActionIcon,
-} from "@mantine/core";
+import { Fieldset, Group, Button, TextInput, Menu, Flex } from "@mantine/core";
 import {
   DragDropContext,
   Droppable,
   Draggable,
   DropResult,
 } from "@hello-pangea/dnd";
-import {
-  IconPlus,
-  IconDotsVertical,
-  IconMenu,
-  IconTrash,
-} from "@tabler/icons-react";
+import { IconPlus, IconDotsVertical, IconMenu } from "@tabler/icons-react";
 import { UseFormReturnType } from "@mantine/form";
+import DeleteButtonDropdown from "./DeleteButtonDropdown";
 
 type EditIngredientsListProps = {
   form: UseFormReturnType<FormValues>;
@@ -77,27 +65,19 @@ export const EditIngredientsList = ({
                       ref={provided.innerRef}
                       {...provided.draggableProps}
                     >
-                      <Menu position="left" offset={-35}>
-                        <Menu.Dropdown>
-                          <Menu.Item>
-                            <ActionIcon
-                              mt={2}
-                              onClick={() =>
-                                deleteItem(
-                                  index,
-                                  ingredients,
-                                  setIngredients,
-                                  "ingredients"
-                                )
-                              }
-                              variant="transparent"
-                              size="sm"
-                              aria-label="Delete"
-                            >
-                              <IconTrash size={24} />
-                            </ActionIcon>
-                          </Menu.Item>
-                        </Menu.Dropdown>
+                      <Menu position="left" offset={-45}>
+                        <DeleteButtonDropdown
+                          onClickDelete={() =>
+                            deleteItem(
+                              index,
+                              ingredients,
+                              setIngredients,
+                              "ingredients"
+                            )
+                          }
+                          type="ingredient"
+                        />
+
                         <Flex {...provided.dragHandleProps}>
                           <IconMenu size="1.2rem" />
                         </Flex>

--- a/src/components/EditInstructionsList.tsx
+++ b/src/components/EditInstructionsList.tsx
@@ -135,6 +135,8 @@ export const EditInstructionsList = ({
                                 </Flex>
                                 <Textarea
                                   radius={"md"}
+                                  autosize
+                                  minRows={1}
                                   rightSection={
                                     <Menu.Target>
                                       <IconDotsVertical
@@ -144,7 +146,6 @@ export const EditInstructionsList = ({
                                   }
                                   style={{ width: "100%" }}
                                   placeholder={`Step ${index + 1}`}
-                                  minRows={3}
                                   value={instruction.text}
                                   onChange={(event) =>
                                     handleTextChange(
@@ -230,6 +231,8 @@ export const EditInstructionsList = ({
                             </Flex>
                             <Textarea
                               radius={"md"}
+                              autosize
+                              minRows={1}
                               rightSection={
                                 <Menu.Target>
                                   <IconDotsVertical
@@ -239,7 +242,6 @@ export const EditInstructionsList = ({
                               }
                               style={{ width: "100%" }}
                               placeholder={`Step ${index + 1}`}
-                              minRows={3}
                               value={instruction.text}
                               onChange={(event) =>
                                 handleTextChange(

--- a/src/components/EditInstructionsList.tsx
+++ b/src/components/EditInstructionsList.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import {
   Fieldset,
   Group,
-  ActionIcon,
   Button,
   Textarea,
   Card,
@@ -17,13 +16,9 @@ import {
   Draggable,
   DropResult,
 } from "@hello-pangea/dnd";
-import {
-  IconPlus,
-  IconTrash,
-  IconDotsVertical,
-  IconMenu,
-} from "@tabler/icons-react";
+import { IconPlus, IconDotsVertical, IconMenu } from "@tabler/icons-react";
 import { UseFormReturnType } from "@mantine/form";
+import DeleteButtonDropdown from "./DeleteButtonDropdown";
 
 type EditInstructionsListProps = {
   form: UseFormReturnType<FormValues>;
@@ -108,31 +103,24 @@ export const EditInstructionsList = ({
                               ref={provided.innerRef}
                               {...provided.draggableProps}
                             >
-                              <Menu position="left" offset={-35}>
-                                <Menu.Dropdown>
-                                  <Menu.Item>
-                                    <ActionIcon
-                                      mt={2}
-                                      onClick={() =>
-                                        deleteItem(
-                                          index,
-                                          sectionedInstructions[sectionIndex]
-                                            .text,
-                                          setSectionedInstructions,
-                                          "instructions",
-                                          sectionIndex
-                                        )
-                                      }
-                                      variant="transparent"
-                                      aria-label="Delete instruction"
-                                    >
-                                      <IconTrash size={24} />
-                                    </ActionIcon>
-                                  </Menu.Item>
-                                </Menu.Dropdown>
+                              <Menu position="left" offset={-45}>
+                                <DeleteButtonDropdown
+                                  onClickDelete={() =>
+                                    deleteItem(
+                                      index,
+                                      sectionedInstructions[sectionIndex].text,
+                                      setSectionedInstructions,
+                                      "instructions",
+                                      sectionIndex
+                                    )
+                                  }
+                                  type="instruction"
+                                />
+
                                 <Flex {...provided.dragHandleProps}>
                                   <IconMenu size="1.2rem" />
                                 </Flex>
+
                                 <Textarea
                                   radius={"md"}
                                   autosize
@@ -206,26 +194,19 @@ export const EditInstructionsList = ({
                           ref={provided.innerRef}
                           {...provided.draggableProps}
                         >
-                          <Menu position="left" offset={-35}>
-                            <Menu.Dropdown>
-                              <Menu.Item>
-                                <ActionIcon
-                                  mt={2}
-                                  onClick={() =>
-                                    deleteItem(
-                                      index,
-                                      instructions,
-                                      setInstructions,
-                                      "instructions"
-                                    )
-                                  }
-                                  variant="transparent"
-                                  aria-label="Delete instruction"
-                                >
-                                  <IconTrash size={24} />
-                                </ActionIcon>
-                              </Menu.Item>
-                            </Menu.Dropdown>
+                          <Menu position="left" offset={-45}>
+                            <DeleteButtonDropdown
+                              onClickDelete={() =>
+                                deleteItem(
+                                  index,
+                                  instructions,
+                                  setInstructions,
+                                  "instructions"
+                                )
+                              }
+                              type="instruction"
+                            />
+
                             <Flex {...provided.dragHandleProps}>
                               <IconMenu size="1.2rem" />
                             </Flex>


### PR DESCRIPTION
From Issue:
- [ ] Current border radius hides text in the corners (Border radiuses should be a group decision so its left out from this PR)
- [x]  Hardcoded height value (with scroll bar) might not be the best UX. Two solution suggestions:
  - [ ] Native HTML enlarge the textarea by dragging lower right corner (Arguably not needed)
  -  [x] Dynamic height values depending on the content. **See screen recording**.

---

Also included in PR:

New component `DeleteButtonDropdown`. Replaces delete action in `EditIngredientsList` and `EditInstructionsList` for individual ingredients / instructions. Styling of the button is changed a bit. **See screen recording**.

---

Dynamic height values:
https://github.com/user-attachments/assets/b3607536-94c2-427a-98d6-3592c130ceb3

New styling of delete button:
https://github.com/user-attachments/assets/8af1b2a9-f24d-401d-af87-7840b7ec800c



