### PR TITLE
fix: checkbox state gets lost when toggling between ingredientsinstructions

### DIFF
--- a/src/app/dashboard/[slug]/page.tsx
+++ b/src/app/dashboard/[slug]/page.tsx
@@ -61,11 +61,11 @@ export default async function RecipePage({
       </Stack>
 
       <ScreenAwakeToggle />
-      <Box component="section" mb={"md"} pb={"md"}>
+      <Box component="section" pb={"xl"}>
         <IngredientsAndInstructionsToggle recipe={convertedRecipe} />
       </Box>
 
-      <Group mb="md">
+      <Group pb={"xl"}>
         {recipe.tags?.map((tagRelation, index) => (
           <Pill key={index} size="md">
             {tagRelation.tag.name}

--- a/src/components/IngredientsAndInstructionsToggle.tsx
+++ b/src/components/IngredientsAndInstructionsToggle.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { Button, Group, List, Stack } from "@mantine/core";
+import { Button, Checkbox, Group, List, Stack } from "@mantine/core";
 import { useState } from "react";
 import RenderedInstructions from "./RenderedInstructions";
 
@@ -12,8 +12,24 @@ export const IngredientsAndInstructionsToggle = ({
 }: IngAndInstToggleProps) => {
   const [view, setView] = useState("ingredients");
 
+  const [checkboxStates, setCheckboxStates] = useState({
+    instructions: Array(recipe.instructions.length).fill(false),
+    ingredients: Array(recipe.ingredients.length).fill(false),
+  });
+
+  const handleCheckboxChange = (
+    type: "instructions" | "ingredients",
+    index: number,
+    checked: boolean
+  ) => {
+    setCheckboxStates((prev) => ({
+      ...prev,
+      [type]: prev[type].map((state, idx) => (idx === index ? checked : state)),
+    }));
+  };
+
   return (
-    <Stack mb={"md"}>
+    <Stack>
       <Group justify="space-between" grow mb="md">
         <Button
           variant={view === "ingredients" ? "filled" : "light"}
@@ -33,7 +49,7 @@ export const IngredientsAndInstructionsToggle = ({
       </Group>
 
       {view === "ingredients" && (
-        <List listStyleType="none">
+        <List listStyleType="none" spacing="xs">
           {recipe.ingredients.map((ingredient, index) => {
             return (
               <List.Item
@@ -44,13 +60,40 @@ export const IngredientsAndInstructionsToggle = ({
                 }}
                 key={index}
               >
-                {ingredient}
+                <Checkbox
+                  size="md"
+                  checked={checkboxStates.ingredients[index]}
+                  onChange={(event) =>
+                    handleCheckboxChange(
+                      "ingredients",
+                      index,
+                      event.currentTarget.checked
+                    )
+                  }
+                  label={
+                    <span
+                      style={{
+                        opacity: checkboxStates.ingredients[index] ? 0.5 : 1,
+                      }}
+                    >
+                      {ingredient}
+                    </span>
+                  }
+                />
               </List.Item>
             );
           })}
         </List>
       )}
-      {view === "instructions" && <RenderedInstructions recipe={recipe} />}
+      {view === "instructions" && (
+        <RenderedInstructions
+          recipe={recipe}
+          checkboxStates={checkboxStates.instructions}
+          onCheckboxChange={(index, checked) =>
+            handleCheckboxChange("instructions", index, checked)
+          }
+        />
+      )}
     </Stack>
   );
 };

--- a/src/components/IngredientsAndInstructionsToggle.tsx
+++ b/src/components/IngredientsAndInstructionsToggle.tsx
@@ -1,7 +1,8 @@
 "use client";
-import { Button, Checkbox, Group, List, Stack } from "@mantine/core";
+import { Button, Flex, Group, Paper, Stack, Text } from "@mantine/core";
 import { useState } from "react";
 import RenderedInstructions from "./RenderedInstructions";
+import RenderedIngredients from "./RenderedIngredients";
 
 type IngAndInstToggleProps = {
   recipe: UserRecipe;
@@ -29,71 +30,72 @@ export const IngredientsAndInstructionsToggle = ({
   };
 
   return (
-    <Stack>
-      <Group justify="space-between" grow mb="md">
-        <Button
-          variant={view === "ingredients" ? "filled" : "light"}
-          size="md"
-          onClick={() => setView("ingredients")}
-        >
-          Ingredients
-        </Button>
+    <>
+      <Flex gap={"sm"} visibleFrom="sm">
+        <Paper miw={"30%"} withBorder radius={"xs"} p="md" shadow="xs">
+          <Text fw={700} size="xl" mb={"md"}>
+            Ingredients
+          </Text>
+          <RenderedIngredients
+            recipe={recipe}
+            checkboxStates={checkboxStates.ingredients}
+            onCheckboxChange={(index, checked) =>
+              handleCheckboxChange("ingredients", index, checked)
+            }
+          />
+        </Paper>
+        <Paper withBorder radius={"xs"} p="md" shadow="xs">
+          <Text fw={700} size="xl" mb={"md"}>
+            Instructions
+          </Text>
+          <RenderedInstructions
+            recipe={recipe}
+            checkboxStates={checkboxStates.instructions}
+            onCheckboxChange={(index, checked) =>
+              handleCheckboxChange("instructions", index, checked)
+            }
+          />
+        </Paper>
+      </Flex>
 
-        <Button
-          variant={view === "instructions" ? "filled" : "light"}
-          size="md"
-          onClick={() => setView("instructions")}
-        >
-          Instructions
-        </Button>
-      </Group>
+      <Stack hiddenFrom="sm">
+        <Group justify="space-between" grow mb="md">
+          <Button
+            variant={view === "ingredients" ? "filled" : "light"}
+            size="md"
+            onClick={() => setView("ingredients")}
+          >
+            Ingredients
+          </Button>
 
-      {view === "ingredients" && (
-        <List listStyleType="none" spacing="xs">
-          {recipe.ingredients.map((ingredient, index) => {
-            return (
-              <List.Item
-                styles={{
-                  itemWrapper: {
-                    display: "inline",
-                  },
-                }}
-                key={index}
-              >
-                <Checkbox
-                  size="md"
-                  checked={checkboxStates.ingredients[index]}
-                  onChange={(event) =>
-                    handleCheckboxChange(
-                      "ingredients",
-                      index,
-                      event.currentTarget.checked
-                    )
-                  }
-                  label={
-                    <span
-                      style={{
-                        opacity: checkboxStates.ingredients[index] ? 0.5 : 1,
-                      }}
-                    >
-                      {ingredient}
-                    </span>
-                  }
-                />
-              </List.Item>
-            );
-          })}
-        </List>
-      )}
-      {view === "instructions" && (
-        <RenderedInstructions
-          recipe={recipe}
-          checkboxStates={checkboxStates.instructions}
-          onCheckboxChange={(index, checked) =>
-            handleCheckboxChange("instructions", index, checked)
-          }
-        />
-      )}
-    </Stack>
+          <Button
+            variant={view === "instructions" ? "filled" : "light"}
+            size="md"
+            onClick={() => setView("instructions")}
+          >
+            Instructions
+          </Button>
+        </Group>
+
+        {view === "ingredients" && (
+          <RenderedIngredients
+            recipe={recipe}
+            checkboxStates={checkboxStates.ingredients}
+            onCheckboxChange={(index, checked) =>
+              handleCheckboxChange("ingredients", index, checked)
+            }
+          />
+        )}
+        {view === "instructions" && (
+          <RenderedInstructions
+            recipe={recipe}
+            checkboxStates={checkboxStates.instructions}
+            onCheckboxChange={(index, checked) =>
+              handleCheckboxChange("instructions", index, checked)
+            }
+          />
+        )}
+      </Stack>
+    </>
   );
 };

--- a/src/components/RenderedIngredients.tsx
+++ b/src/components/RenderedIngredients.tsx
@@ -1,0 +1,47 @@
+import { Checkbox, List } from "@mantine/core";
+
+type RenderedIngredientsProps = {
+  recipe: UserRecipe;
+  checkboxStates: boolean[];
+  onCheckboxChange: (index: number, checked: boolean) => void;
+};
+
+export default function RenderedIngredients({
+  recipe,
+  checkboxStates,
+  onCheckboxChange,
+}: RenderedIngredientsProps) {
+  return (
+    <List listStyleType="none" spacing="xs">
+      {recipe.ingredients.map((ingredient, index) => {
+        return (
+          <List.Item
+            styles={{
+              itemWrapper: {
+                display: "inline",
+              },
+            }}
+            key={index}
+          >
+            <Checkbox
+              size="md"
+              checked={checkboxStates[index]}
+              onChange={(event) =>
+                onCheckboxChange(index, event.currentTarget.checked)
+              }
+              label={
+                <span
+                  style={{
+                    opacity: checkboxStates[index] ? 0.5 : 1,
+                  }}
+                >
+                  {ingredient}
+                </span>
+              }
+            />
+          </List.Item>
+        );
+      })}
+    </List>
+  );
+}

--- a/src/components/RenderedInstructions.tsx
+++ b/src/components/RenderedInstructions.tsx
@@ -1,4 +1,4 @@
-import { Checkbox, List, Title } from "@mantine/core";
+import { Box, Checkbox, List, Text } from "@mantine/core";
 
 type RenderProps = {
   recipe: UserRecipe;
@@ -49,8 +49,10 @@ export default function RenderedInstructions({
         {recipe.instructions.map((section, sectionIndex) => {
           if (typeof section === "object" && "name" in section) {
             return (
-              <div key={sectionIndex}>
-                <Title order={3}>{section.name}</Title>
+              <Box key={sectionIndex} pb={"sm"}>
+                <Text pl={"md"} ml={"lg"} fw={"bold"}>
+                  {section.name}
+                </Text>
                 <List listStyleType="none" spacing="xs">
                   {section.text.map((instruction: string, index: number) => (
                     <List.Item
@@ -80,7 +82,7 @@ export default function RenderedInstructions({
                     </List.Item>
                   ))}
                 </List>
-              </div>
+              </Box>
             );
           }
         })}

--- a/src/components/RenderedInstructions.tsx
+++ b/src/components/RenderedInstructions.tsx
@@ -1,13 +1,16 @@
 import { Checkbox, List, Title } from "@mantine/core";
-import { useRef } from "react";
 
 type RenderProps = {
   recipe: UserRecipe;
+  checkboxStates: boolean[];
+  onCheckboxChange: (index: number, checked: boolean) => void;
 };
 
-export default function RenderedInstructions({ recipe }: RenderProps) {
-  const labelRefs = useRef<(HTMLSpanElement | null)[]>([]);
-
+export default function RenderedInstructions({
+  recipe,
+  checkboxStates,
+  onCheckboxChange,
+}: RenderProps) {
   if (typeof recipe.instructions[0] === "string") {
     return (
       <List listStyleType="none" spacing="xs">
@@ -22,18 +25,14 @@ export default function RenderedInstructions({ recipe }: RenderProps) {
           >
             <Checkbox
               size="md"
-              onChange={(event) => {
-                if (labelRefs.current[index]) {
-                  labelRefs.current[index].style.opacity = event.currentTarget
-                    .checked
-                    ? "0.4"
-                    : "1";
-                }
-              }}
+              checked={checkboxStates[index]}
+              onChange={(event) =>
+                onCheckboxChange(index, event.currentTarget.checked)
+              }
               label={
                 <span
-                  ref={(el) => {
-                    labelRefs.current[index] = el;
+                  style={{
+                    opacity: checkboxStates[index] ? 0.5 : 1,
                   }}
                 >
                   {`${index + 1}. ${instruction}`}
@@ -52,7 +51,7 @@ export default function RenderedInstructions({ recipe }: RenderProps) {
             return (
               <div key={sectionIndex}>
                 <Title order={3}>{section.name}</Title>
-                <List type="ordered" spacing="xs">
+                <List listStyleType="none" spacing="xs">
                   {section.text.map((instruction: string, index: number) => (
                     <List.Item
                       styles={{
@@ -62,7 +61,22 @@ export default function RenderedInstructions({ recipe }: RenderProps) {
                       }}
                       key={index}
                     >
-                      {instruction}
+                      <Checkbox
+                        size="md"
+                        checked={checkboxStates[index]}
+                        onChange={(event) =>
+                          onCheckboxChange(index, event.currentTarget.checked)
+                        }
+                        label={
+                          <span
+                            style={{
+                              opacity: checkboxStates[index] ? 0.5 : 1,
+                            }}
+                          >
+                            {`${index + 1}. ${instruction}`}
+                          </span>
+                        }
+                      />
                     </List.Item>
                   ))}
                 </List>


### PR DESCRIPTION
- Add useState to save checked boxes while toggling between ingredients and instructions
- No toggle between ingredients and instructions for larger screens, both are visible at the same time