### PR TITLE
fix: ensure grag handle cursor displays on first hover

### DIFF
--- a/src/components/EditIngredientsList.tsx
+++ b/src/components/EditIngredientsList.tsx
@@ -78,7 +78,10 @@ export const EditIngredientsList = ({
                           type="ingredient"
                         />
 
-                        <Flex {...provided.dragHandleProps}>
+                        <Flex
+                          {...provided.dragHandleProps}
+                          style={{ cursor: "grab" }}
+                        >
                           <IconMenu size="1.2rem" />
                         </Flex>
                         <TextInput

--- a/src/components/EditInstructionsList.tsx
+++ b/src/components/EditInstructionsList.tsx
@@ -117,7 +117,10 @@ export const EditInstructionsList = ({
                                   type="instruction"
                                 />
 
-                                <Flex {...provided.dragHandleProps}>
+                                <Flex
+                                  {...provided.dragHandleProps}
+                                  style={{ cursor: "grab" }}
+                                >
                                   <IconMenu size="1.2rem" />
                                 </Flex>
 
@@ -207,7 +210,10 @@ export const EditInstructionsList = ({
                               type="instruction"
                             />
 
-                            <Flex {...provided.dragHandleProps}>
+                            <Flex
+                              {...provided.dragHandleProps}
+                              style={{ cursor: "grab" }}
+                            >
                               <IconMenu size="1.2rem" />
                             </Flex>
                             <Textarea


### PR DESCRIPTION
Added cursor: grab as a style prop. Now it shows on first hover as well.