### PR TITLE
fix: changed color on tags

### DIFF
--- a/src/app/dashboard/[slug]/page.tsx
+++ b/src/app/dashboard/[slug]/page.tsx
@@ -3,20 +3,19 @@ import Link from "next/link";
 import {
   Anchor,
   Group,
-  Pill,
+  // Pill,
   Stack,
   Title,
   Text,
   Box,
   Chip,
 } from "@mantine/core";
-import { IconHash, IconPencil, IconToolsKitchen2 } from "@tabler/icons-react";
+import { IconHash, IconPencil } from "@tabler/icons-react";
 import { IngredientsAndInstructionsToggle } from "@/components/IngredientsAndInstructionsToggle";
 import { getAuth } from "@/lib/auth";
 import { notFound } from "next/navigation";
 import { ScreenAwakeToggle } from "@/components/ScreenAwakeToggle";
 import { Breadcrumbs } from "@/components/Breadcrumbs";
-import { useState } from "react";
 
 export default async function RecipePage({
   searchParams,

--- a/src/app/dashboard/[slug]/page.tsx
+++ b/src/app/dashboard/[slug]/page.tsx
@@ -1,16 +1,7 @@
 import prisma from "@/lib/db";
 import Link from "next/link";
-import {
-  Anchor,
-  Group,
-  // Pill,
-  Stack,
-  Title,
-  Text,
-  Box,
-  Chip,
-} from "@mantine/core";
-import { IconHash, IconPencil } from "@tabler/icons-react";
+import { Anchor, Group, Stack, Title, Text, Box, Badge } from "@mantine/core";
+import { IconPencil } from "@tabler/icons-react";
 import { IngredientsAndInstructionsToggle } from "@/components/IngredientsAndInstructionsToggle";
 import { getAuth } from "@/lib/auth";
 import { notFound } from "next/navigation";
@@ -76,17 +67,19 @@ export default async function RecipePage({
 
       <Group pb={"xl"}>
         {recipe.tags?.map((tagRelation, index) => (
-          <Chip
+          <Badge
             key={index}
             defaultChecked
             color="dustyRed"
             variant="light"
-            size="sm"
-            checked={true}
-            icon={<IconHash size={14} />}
+            size="lg"
+            style={{
+              textTransform: "none",
+              fontWeight: 600,
+            }}
           >
             {tagRelation.tag.name}
-          </Chip>
+          </Badge>
         ))}
       </Group>
     </>

--- a/src/app/dashboard/[slug]/page.tsx
+++ b/src/app/dashboard/[slug]/page.tsx
@@ -1,12 +1,22 @@
 import prisma from "@/lib/db";
 import Link from "next/link";
-import { Anchor, Group, Pill, Stack, Title, Text, Box } from "@mantine/core";
-import { IconPencil } from "@tabler/icons-react";
+import {
+  Anchor,
+  Group,
+  Pill,
+  Stack,
+  Title,
+  Text,
+  Box,
+  Chip,
+} from "@mantine/core";
+import { IconHash, IconPencil, IconToolsKitchen2 } from "@tabler/icons-react";
 import { IngredientsAndInstructionsToggle } from "@/components/IngredientsAndInstructionsToggle";
 import { getAuth } from "@/lib/auth";
 import { notFound } from "next/navigation";
 import { ScreenAwakeToggle } from "@/components/ScreenAwakeToggle";
 import { Breadcrumbs } from "@/components/Breadcrumbs";
+import { useState } from "react";
 
 export default async function RecipePage({
   searchParams,
@@ -67,9 +77,17 @@ export default async function RecipePage({
 
       <Group pb={"xl"}>
         {recipe.tags?.map((tagRelation, index) => (
-          <Pill key={index} size="md">
+          <Chip
+            key={index}
+            defaultChecked
+            color="dustyRed"
+            variant="light"
+            size="sm"
+            checked={true}
+            icon={<IconHash size={14} />}
+          >
             {tagRelation.tag.name}
-          </Pill>
+          </Chip>
         ))}
       </Group>
     </>

--- a/src/app/dashboard/[slug]/page.tsx
+++ b/src/app/dashboard/[slug]/page.tsx
@@ -69,7 +69,6 @@ export default async function RecipePage({
         {recipe.tags?.map((tagRelation, index) => (
           <Badge
             key={index}
-            defaultChecked
             color="dustyRed"
             variant="light"
             size="lg"


### PR DESCRIPTION
This PR suggests red tags (variant light). An easy way to implement this change on only these tags (the ones on the recipe page) was to switch to Badge or Chip components instead of Pills. The downside with the Chip component is that it requires an icon and has has a pointer arrow by default. 

Before:
<img width="414" alt="Skärmavbild 2024-11-18 kl  17 27 35" src="https://github.com/user-attachments/assets/69921148-b736-4644-8d84-599cf1a0b8d9">
<img width="270" alt="Skärmavbild 2024-11-19 kl  10 54 35" src="https://github.com/user-attachments/assets/bd71a3fd-a4a1-4456-ae0b-36576e9deb7d">

Option 1: Badges
<img width="292" alt="Skärmavbild 2024-11-19 kl  13 28 33" src="https://github.com/user-attachments/assets/91b45d24-3bba-4d4e-8e25-686e8385dd74">
<img width="293" alt="Skärmavbild 2024-11-19 kl  13 28 48" src="https://github.com/user-attachments/assets/402ef390-b197-4199-b24b-3cc31e4b7a00">

Option 2: Chips
<img width="342" alt="Skärmavbild 2024-11-19 kl  10 53 14" src="https://github.com/user-attachments/assets/fde9a5c1-0703-4cba-a351-f4ecdfb1040c">
<img width="339" alt="Skärmavbild 2024-11-19 kl  10 54 07" src="https://github.com/user-attachments/assets/0c5dea61-9a60-47d9-87e2-fd003646218c">

