### PR TITLE
fix: only display banner if no session and minor layout updates

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -12,7 +12,7 @@ import Link from "next/link";
 export default function About() {
   return (
     <Center>
-      <Stack pb={"xl"} maw={"60ch"}>
+      <Stack mb="4rem" maw={"60ch"}>
         <Stack mt={"xl"}>
           <Title ta="center">About us</Title>
           <Text>

--- a/src/app/dashboard/[slug]/edit/page.tsx
+++ b/src/app/dashboard/[slug]/edit/page.tsx
@@ -3,6 +3,7 @@ import { EditRecipeForm } from "@/components/EditRecipeForm";
 import { getAuth } from "@/lib/auth";
 import prisma from "@/lib/db";
 import { getUserTags } from "@/lib/queries";
+import { Space } from "@mantine/core";
 import { notFound } from "next/navigation";
 
 export default async function EditRecipePage({
@@ -36,6 +37,7 @@ export default async function EditRecipePage({
       <Breadcrumbs />
 
       <EditRecipeForm recipe={convertedRecipe} userTags={userTags} />
+      <Space h="4rem" />
     </>
   );
 }

--- a/src/app/dashboard/[slug]/page.tsx
+++ b/src/app/dashboard/[slug]/page.tsx
@@ -1,6 +1,15 @@
 import prisma from "@/lib/db";
 import Link from "next/link";
-import { Anchor, Group, Stack, Title, Text, Box, Badge } from "@mantine/core";
+import {
+  Anchor,
+  Group,
+  Stack,
+  Title,
+  Text,
+  Box,
+  Badge,
+  Space,
+} from "@mantine/core";
 
 import { IngredientsAndInstructionsToggle } from "@/components/IngredientsAndInstructionsToggle";
 import { getAuth } from "@/lib/auth";
@@ -8,6 +17,7 @@ import { notFound } from "next/navigation";
 import { ScreenAwakeToggle } from "@/components/ScreenAwakeToggle";
 import { Breadcrumbs } from "@/components/Breadcrumbs";
 import EditRecipeButton from "@/components/EditRecipeButton";
+import { IconClockHour4, IconToolsKitchen2 } from "@tabler/icons-react";
 
 export default async function RecipePage({
   searchParams,
@@ -68,13 +78,19 @@ export default async function RecipePage({
                 {recipe.author}
               </Anchor>
             </Text>
-            <Text size="xs">Total time: {recipe.time}</Text>
-            <Text size="xs">Servings: {recipe.yield}</Text>
+            <Group gap={"xs"}>
+              <IconClockHour4 size={16} />
+              <Text size="xs">Total time: {recipe.time}</Text>
+            </Group>
+
+            <Group gap={"xs"}>
+              <IconToolsKitchen2 size={16} />
+              <Text size="xs">Servings: {recipe.yield}</Text>
+            </Group>
           </Group>
 
           {/* The ScreenAwakeToggle is rendered inside IngredientsAndInstructionsToggle on small screens */}
           <ScreenAwakeToggle visibleFrom="sm" labelPosition="left" />
-
         </Group>
       </Stack>
 
@@ -82,7 +98,7 @@ export default async function RecipePage({
         <IngredientsAndInstructionsToggle recipe={convertedRecipe} />
       </Box>
 
-      <Group pb={"xl"}>
+      <Group>
         {recipe.tags?.map((tagRelation, index) => (
           <Badge
             key={index}
@@ -98,6 +114,7 @@ export default async function RecipePage({
           </Badge>
         ))}
       </Group>
+      <Space h="4rem" />
     </>
   );
 }

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -39,7 +39,7 @@ export default async function Dashboard() {
         </Group>
       </Box>
       <RecipesList tags={tags} recipes={convertedRecipes} />
-      <Space h="xl" />
+      <Space h="4rem" />
     </>
   );
 }

--- a/src/app/welcome/page.tsx
+++ b/src/app/welcome/page.tsx
@@ -32,7 +32,7 @@ export default async function Welcome() {
       </Box>
       <RecipeForm session={session} userTags={userTags} />
       <RecipesList recipes={convertedRecipes} title="Your latest recipes" />
-      <Space h="xl" />
+      <Space h="4rem" />
     </Flex>
   );
 }

--- a/src/components/EditRecipeForm.tsx
+++ b/src/components/EditRecipeForm.tsx
@@ -9,7 +9,6 @@ import {
   Flex,
   Group,
   Paper,
-  Space,
   TagsInput,
   Text,
   TextInput,
@@ -238,7 +237,7 @@ export const EditRecipeForm = ({ recipe, userTags }: EditRecipeProps) => {
 
         {/* General info */}
 
-        <Fieldset radius={"sm"} mb="md" legend="Recipe information">
+        <Fieldset radius={"sm"} mt="lg" mb="lg" legend="Recipe information">
           <TextInput
             radius={"sm"}
             label="Title"
@@ -281,7 +280,7 @@ export const EditRecipeForm = ({ recipe, userTags }: EditRecipeProps) => {
           view={view}
         />
 
-        <Fieldset radius={"sm"} mb="md" legend="Tags">
+        <Fieldset radius={"sm"} legend="Tags">
           <TagsInput
             radius={"sm"}
             label="Recipe tags"
@@ -294,8 +293,6 @@ export const EditRecipeForm = ({ recipe, userTags }: EditRecipeProps) => {
             comboboxProps={{ dropdownPadding: 8 }}
           />
         </Fieldset>
-
-        <Space h="md" />
       </form>
     </>
   );

--- a/src/components/IngredientsAndInstructionsToggle.tsx
+++ b/src/components/IngredientsAndInstructionsToggle.tsx
@@ -14,7 +14,7 @@ import { useState } from "react";
 import RenderedInstructions from "./RenderedInstructions";
 import RenderedIngredients from "./RenderedIngredients";
 import { ScreenAwakeToggle } from "./ScreenAwakeToggle";
-import { IconLadle, IconMushroom } from "@tabler/icons-react";
+import { IconCarrot, IconLadle } from "@tabler/icons-react";
 
 type IngAndInstToggleProps = {
   recipe: UserRecipe;
@@ -123,9 +123,7 @@ export const IngredientsAndInstructionsToggle = ({
                 label: (
                   <>
                     <Center style={{ gap: 10 }}>
-                      <IconMushroom
-                        style={{ width: rem(16), height: rem(16) }}
-                      />
+                      <IconCarrot style={{ width: rem(16), height: rem(16) }} />
                       <Text size="sm" visibleFrom="xs">
                         Ingredients
                       </Text>

--- a/src/components/RecipeForm.tsx
+++ b/src/components/RecipeForm.tsx
@@ -188,7 +188,6 @@ export const RecipeForm = ({ session, userTags }: RecipeFormProps) => {
           component="section"
           style={{ justifySelf: "flex-start" }}
         >
-
           <Divider my="md" />
 
           <Box
@@ -227,9 +226,8 @@ export const RecipeForm = ({ session, userTags }: RecipeFormProps) => {
       {/* Only shown when there is no scraped recipe, user is not logged in and no notifications are on screen */}
       <Transition
         mounted={
-          !recipe?.ingredients &&
-          !session &&
-          notificationsStore.notifications.length === 0
+          (!session && notificationsStore.notifications.length === 0) ||
+          (!session && !!recipe)
         }
         transition="slide-down"
         duration={300}
@@ -241,7 +239,6 @@ export const RecipeForm = ({ session, userTags }: RecipeFormProps) => {
           </Box>
         )}
       </Transition>
-      {recipe && <CreateAccountBanner />}
     </Stack>
   );
 };


### PR DESCRIPTION
- Display banner if there is no session and no notifications, or if there is no session but is a recipe. This so recipe and banner show up at the same time, otherwise banner would appear after a delay (when notification is done).
- Add consistent margin bottom for all pages
- Add a little bit more padding in edit recipe form
- Add icons for time and serving in `[slug]/page.tsx`
- Replace mushroom icon with carrot icon in toggle